### PR TITLE
fix: datepicker broken

### DIFF
--- a/src/components/crud/fields/fieldDateRange.vue
+++ b/src/components/crud/fields/fieldDateRange.vue
@@ -51,9 +51,9 @@ export default {
 
     formatValueToModel(value) {
       if (value != null) {
-        const m = dayjs(value, this.getDateFormat());
-        value = m.format(this.getDateFormat());
+        value = dayjs(value).format(this.getDateFormat());
       }
+      console.log(value);
       return value;
     }
   },

--- a/src/components/crud/fields/fieldDateTime.vue
+++ b/src/components/crud/fields/fieldDateTime.vue
@@ -1,5 +1,6 @@
 <template>
   <div class="input-group">
+    {{value}}
     <datetime
       v-bind="schema"
       class="field-date-fw"
@@ -75,8 +76,7 @@ export default {
 
     formatValueToModel(value) {
       if (value != null) {
-        const m = dayjs(value, this.getDateFormat());
-        value = m.format(this.getDateFormat());
+        value = dayjs(value).format(this.getDateFormat());
       }
       return value;
     }

--- a/src/translations/fr.json
+++ b/src/translations/fr.json
@@ -39,7 +39,7 @@
       "lesser-than": "Est plus petit que (<)",
       "lesser-or-equals": "Est égal ou petit que (<=)",
       "between": "Entre",
-      "not-between": "N'est pads entre'",
+      "not-between": "N'est pas entre'",
       "contains": "Contient",
       "not-contains": "Ne contient pas",
       "starts-with": "Commence par",


### PR DESCRIPTION
Due to bad formatting

fix: $not_between translation

> Trello card : https://trello.com/c/4oA4ObPD/76-les-datepickers-sont-cass%C3%A9s-suite-%C3%A0-la-mise-en-place-de-dayjs