### PR TITLE
refactor: move all custom actions from options to first level

### DIFF
--- a/src/components/crud/AwesomeCrud.vue
+++ b/src/components/crud/AwesomeCrud.vue
@@ -21,6 +21,9 @@
             :display-header="awFormDisplayHeader"
             :has-previous="hasPrevious"
             :has-next="hasNext"
+            :actions="_actions"
+            :custom-inline-actions="_customInlineActions"
+            :custom-aw-form-top-actions="_customAwFormTopActions"
             @create="goToCreatePage"
             @view="goToViewPage"
             @nestedView="nestedViewFunction"
@@ -63,6 +66,9 @@
             :display-header="awFormDisplayHeader"
             :has-previous="hasPrevious"
             :has-next="hasNext"
+            :actions="_actions"
+            :custom-inline-actions="_customInlineActions"
+            :custom-aw-form-top-actions="_customAwFormTopActions"
             @create="goToCreatePage"
             @view="goToViewPage"
             @nestedView="nestedViewFunction"
@@ -235,6 +241,9 @@
             "
             v-bind="$props"
             :actions="_actions"
+            :custom-inline-actions="_customInlineActions"
+            :custom-table-top-actions="_customTableTopActions"
+            :custom-bulk-actions="_customBulkActions"
             :api-query-headers="mergedOptions.headerParams"
             :api-query-params="mergedOptions.queryParams"
             :apiRequestConfig="apiRequestConfig"
@@ -354,10 +363,6 @@ const defaultOptions = {
   detailPageMode: 'sidebar', // fade | slide | full
   detailPageLayout: null, // fade | slide | full
   columnsDisplayed: 10,
-  customInlineActions: [],
-  customBulkActions: [],
-  customAwFormTopActions: [],
-  customTabletopActions: []
 };
 
 const listOptions = {
@@ -600,6 +605,26 @@ export default {
       default: () => defaultActions,
       note: 'actions active in this instance'
     },
+    customInlineActions: {
+      type: Array,
+      default: () => [],
+      note: 'custom action in footer and in awTable row'
+    },
+    customBulkActions: {
+      type: Array,
+      default: () => [],
+      note: 'custom action for bulk'
+    },
+    customTableTopActions: {
+      type: Array,
+      default: () => [],
+      note: 'custom table top actions'
+    },
+    customAwFormTopActions: {
+      type: Array,
+      default: () => [],
+      note: 'custom top action for awForm'
+    },
 
     savePaginationState: {
       type: Boolean,
@@ -824,6 +849,30 @@ export default {
         defaultActions,
         this.actions || (this.mergedOptions && this.mergedOptions.actions) // old location kept for BC
       );
+    },
+
+    _customAwFormTopActions() {
+      return _.merge({},
+          this.customAwFormTopActions || (this.mergedOptions && this.mergedOptions.customAwFormTopActions) // old location kept
+      )
+    },
+
+    _customInlineActions() {
+      return _.merge({},
+      this.customInlineActions || (this.mergedOptions && this.mergedOptions.customInlineActions) // old location kept
+      )
+    },
+
+    _customTableTopActions() {
+      return _.merge({},
+          this.customTableTopActions || (this.mergedOptions && this.mergedOptions.customTableTopActions) // old location kept
+      )
+    },
+
+    _customBulkActions() {
+      return _.merge({},
+          this.customBulkActions || (this.mergedOptions && this.mergedOptions.customBulkActions) // old location kept
+      )
     },
 
     _displayModeHasPartialDisplay() {

--- a/src/components/crud/AwesomeCrud.vue
+++ b/src/components/crud/AwesomeCrud.vue
@@ -127,9 +127,9 @@
         <div class="col-12" v-show="showItemsListSectionComputed">
           <div class="text-right">
             <slot name="top-right-buttons">
-              <template v-if="options && options.customTopRightActions">
+              <template v-if="_customTopRightActions">
                 <button
-                  v-for="(action, index) in options.customTopRightActions"
+                  v-for="(action, index) in _customTopRightActions"
                   :key="index"
                   class="btn btn-simple btn-main-style"
                   :class="action.class"
@@ -605,6 +605,11 @@ export default {
       default: () => defaultActions,
       note: 'actions active in this instance'
     },
+    customTopRightActions: {
+      type: Array,
+      default: () => [],
+      note: 'custom action in top right of awCrud'
+    },
     customInlineActions: {
       type: Array,
       default: () => [],
@@ -860,6 +865,12 @@ export default {
     _customInlineActions() {
       return _.merge([],
       this.customInlineActions || (this.mergedOptions && this.mergedOptions.customInlineActions) // old location kept
+      )
+    },
+
+    _customTopRightActions() {
+      return _.merge([],
+          this.customTopRightActions || (this.mergedOptions && this.mergedOptions.customTopRightActions) // old location kept
       )
     },
 

--- a/src/components/crud/AwesomeCrud.vue
+++ b/src/components/crud/AwesomeCrud.vue
@@ -852,25 +852,25 @@ export default {
     },
 
     _customAwFormTopActions() {
-      return _.merge({},
+      return _.merge([],
           this.customAwFormTopActions || (this.mergedOptions && this.mergedOptions.customAwFormTopActions) // old location kept
       )
     },
 
     _customInlineActions() {
-      return _.merge({},
+      return _.merge([],
       this.customInlineActions || (this.mergedOptions && this.mergedOptions.customInlineActions) // old location kept
       )
     },
 
     _customTableTopActions() {
-      return _.merge({},
+      return _.merge([],
           this.customTableTopActions || (this.mergedOptions && this.mergedOptions.customTableTopActions) // old location kept
       )
     },
 
     _customBulkActions() {
-      return _.merge({},
+      return _.merge([],
           this.customBulkActions || (this.mergedOptions && this.mergedOptions.customBulkActions) // old location kept
       )
     },

--- a/src/components/crud/AwesomeCrud.vue
+++ b/src/components/crud/AwesomeCrud.vue
@@ -23,7 +23,7 @@
             :has-next="hasNext"
             :actions="_actions"
             :custom-inline-actions="_customInlineActions"
-            :custom-aw-form-top-actions="_customAwFormTopActions"
+            :custom-top-actions="_customFormTopActions"
             @create="goToCreatePage"
             @view="goToViewPage"
             @nestedView="nestedViewFunction"
@@ -68,7 +68,7 @@
             :has-next="hasNext"
             :actions="_actions"
             :custom-inline-actions="_customInlineActions"
-            :custom-aw-form-top-actions="_customAwFormTopActions"
+            :custom-top-actions="_customFormTopActions"
             @create="goToCreatePage"
             @view="goToViewPage"
             @nestedView="nestedViewFunction"
@@ -362,7 +362,7 @@ const defaultOptions = {
   initialDisplayMode: 'table', // table | list | kanban
   detailPageMode: 'sidebar', // fade | slide | full
   detailPageLayout: null, // fade | slide | full
-  columnsDisplayed: 10,
+  columnsDisplayed: 10
 };
 
 const listOptions = {
@@ -625,12 +625,11 @@ export default {
       default: () => [],
       note: 'custom table top actions'
     },
-    customAwFormTopActions: {
+    customFormTopActions: {
       type: Array,
       default: () => [],
-      note: 'custom top action for awForm'
+      note: 'custom top action to display inside view and edit forms'
     },
-
     savePaginationState: {
       type: Boolean,
       default: true,
@@ -856,34 +855,39 @@ export default {
       );
     },
 
-    _customAwFormTopActions() {
-      return _.merge([],
-          this.customAwFormTopActions || (this.mergedOptions && this.mergedOptions.customAwFormTopActions) // old location kept
-      )
+    _customFormTopActions() {
+      return _.merge(
+        [],
+        this.customFormTopActions || (this.mergedOptions && this.mergedOptions.customFormTopActions) // old location kept
+      );
     },
 
     _customInlineActions() {
-      return _.merge([],
-      this.customInlineActions || (this.mergedOptions && this.mergedOptions.customInlineActions) // old location kept
-      )
+      return _.merge(
+        [],
+        this.customInlineActions || (this.mergedOptions && this.mergedOptions.customInlineActions) // old location kept
+      );
     },
 
     _customTopRightActions() {
-      return _.merge([],
-          this.customTopRightActions || (this.mergedOptions && this.mergedOptions.customTopRightActions) // old location kept
-      )
+      return _.merge(
+        [],
+        this.customTopRightActions || (this.mergedOptions && this.mergedOptions.customTopRightActions) // old location kept
+      );
     },
 
     _customTableTopActions() {
-      return _.merge([],
-          this.customTableTopActions || (this.mergedOptions && this.mergedOptions.customTableTopActions) // old location kept
-      )
+      return _.merge(
+        [],
+        this.customTableTopActions || (this.mergedOptions && this.mergedOptions.customTableTopActions) // old location kept
+      );
     },
 
     _customBulkActions() {
-      return _.merge([],
-          this.customBulkActions || (this.mergedOptions && this.mergedOptions.customBulkActions) // old location kept
-      )
+      return _.merge(
+        [],
+        this.customBulkActions || (this.mergedOptions && this.mergedOptions.customBulkActions) // old location kept
+      );
     },
 
     _displayModeHasPartialDisplay() {

--- a/src/components/crud/AwesomeForm.vue
+++ b/src/components/crud/AwesomeForm.vue
@@ -41,7 +41,7 @@
                       </h3>
 
                       <div
-                        v-if="_useCustomLayout && _actions.editLayout"
+                        v-if="_useCustomLayout && actions.editLayout"
                         class="btn-group m-0 aw-form-header-actions"
                         style="flex:auto"
                       >
@@ -151,8 +151,8 @@
                         {{ $t(mode === 'view' ? 'AwesomeCrud.labels.view' : 'AwesomeCrud.labels.edit') }} {{ _name }}
                         <b>{{ _editItemTile }}</b>
                       </h3>
-                      <div class="btn-group m-0 aw-form-header-actions" v-if="mergedOptions.customAwFormTopActions">
-                        <template v-for="(action, index) in mergedOptions.customAwFormTopActions">
+                      <div class="btn-group m-0 aw-form-header-actions" v-if="customAwFormTopActions">
+                        <template v-for="(action, index) in customAwFormTopActions">
                           <div v-if="action.type === 'dropdown' && action.children" class="dropdown" :key="index">
                             <button
                               class="btn dropdown-toggle"
@@ -210,7 +210,7 @@
                         </template>
                       </div>
                       <div
-                        v-if="_useCustomLayout && _actions.editLayout"
+                        v-if="_useCustomLayout && actions.editLayout"
                         class="btn-group m-0 aw-form-header-actions"
                         style="flex:auto"
                       >
@@ -254,7 +254,7 @@
 
                       <!-- create a subcomponent -->
                       <template v-if="!editLayoutMode && (mode === 'edit' || mode === 'view' || _isANestedDetailView)">
-                        <div class="ml-1 aw-form-pagination" v-if="_actions.formPagination && (hasPrevious || hasNext)">
+                        <div class="ml-1 aw-form-pagination" v-if="actions.formPagination && (hasPrevious || hasNext)">
                           <div class="btn-group">
                             <button
                               @click="!!hasPrevious && $emit('aw-select-previous-item')"
@@ -527,8 +527,8 @@
                         >
                           {{ $t('AwesomeCrud.buttons.cancel') }}
                         </button>
-                        <template v-if="mergedOptions.customInlineActions">
-                          <template v-for="(action, index) in mergedOptions.customInlineActions">
+                        <template v-if="customInlineActions">
+                          <template v-for="(action, index) in customInlineActions">
                             <button
                               type="button"
                               :key="index"
@@ -554,7 +554,7 @@
                         </template>
 
                         <button
-                          v-if="_actions.delete && !mergedOptions.noActions"
+                          v-if="actions.delete && !mergedOptions.noActions"
                           type="button"
                           class="btn btn-danger btn-main-style ml-2"
                           @click.prevent.stop="deleteFunction(selectedItem)"
@@ -566,7 +566,7 @@
                           {{ $t('AwesomeCrud.buttons.save') }}
                         </button>
                         <button
-                          v-if="mode === 'view' && _actions.edit && !mergedOptions.noActions"
+                          v-if="mode === 'view' && actions.edit && !mergedOptions.noActions"
                           type="button"
                           class="btn btn-info btn-main-style ml-2"
                           @click.prevent.stop="editFunction(selectedItem)"
@@ -688,10 +688,6 @@ const defaultOptions = {
   queryParams: {},
   stats: false,
   autoRefresh: false, // or integer in seconds
-  customInlineActions: [],
-  customBulkActions: [],
-  customAwFormTopActions: [],
-  customTabletopActions: [],
   responseField: 'body',
   useCustomLayout: false
 };
@@ -867,6 +863,16 @@ export default {
       type: Object,
       default: () => defaultActions,
       note: 'actions active in this instance'
+    },
+    customInlineActions: {
+      type: Array,
+      default: () => [],
+      note: 'custom action in footer and in awTable row'
+    },
+    customAwFormTopActions: {
+      type: Array,
+      default: () => [],
+      note: 'custom top actions'
     },
     layout: {
       type: [Array, Object],
@@ -1260,13 +1266,13 @@ export default {
     },
     mergeOptions() {
       /** @fix deletePermitted is not used. Cross check with the intranet, and delete*/
-      if (this.options && this.options.deletePermitted && this._actions.delete) {
+      if (this.options && this.options.deletePermitted && this.actions.delete) {
         if (
           this.$store &&
           this.$store.state &&
           !this.options.deletePermitted.some((v) => this.$store.state.user.roles.indexOf(v.toUpperCase()) >= 0)
         ) {
-          this._actions.delete = false;
+          this.actions.delete = false;
         }
       }
       this.mergedOptions = _.merge({}, defaultOptions, this.mergedOptions, this.options);

--- a/src/components/crud/AwesomeForm.vue
+++ b/src/components/crud/AwesomeForm.vue
@@ -151,8 +151,8 @@
                         {{ $t(mode === 'view' ? 'AwesomeCrud.labels.view' : 'AwesomeCrud.labels.edit') }} {{ _name }}
                         <b>{{ _editItemTile }}</b>
                       </h3>
-                      <div class="btn-group m-0 aw-form-header-actions" v-if="customAwFormTopActions">
-                        <template v-for="(action, index) in customAwFormTopActions">
+                      <div class="btn-group m-0 aw-form-header-actions" v-if="customTopActions">
+                        <template v-for="(action, index) in customTopActions">
                           <div v-if="action.type === 'dropdown' && action.children" class="dropdown" :key="index">
                             <button
                               class="btn dropdown-toggle"
@@ -869,7 +869,7 @@ export default {
       default: () => [],
       note: 'custom action in footer and in awTable row'
     },
-    customAwFormTopActions: {
+    customTopActions: {
       type: Array,
       default: () => [],
       note: 'custom top actions'

--- a/src/components/table/AwesomeTable.vue
+++ b/src/components/table/AwesomeTable.vue
@@ -245,8 +245,8 @@
           @on-selected-rows-change="onSelectionChanged"
         >
           <div slot="selected-row-actions">
-            <template v-if="optionsComputed && optionsComputed.customBulkActions">
-              <template v-for="(action, index) in optionsComputed.customBulkActions">
+            <template v-if="customBulkActions">
+              <template v-for="(action, index) in customBulkActions">
                 <button
                   :key="index"
                   class="btn btn-primary btn-simple"
@@ -300,9 +300,9 @@
               :opens="'left'"
               @update="onDateFilter"
             />
-
-            <template v-if="optionsComputed && optionsComputed.customTableTopActions">
-              <template v-for="(action, index) in optionsComputed.customTableTopActions">
+            {{customTabletopActions}}
+            <template v-if="customTableTopActions">
+              <template v-for="(action, index) in customTableTopActions">
                 <template v-if="!action.canDisplay || action.canDisplay({ item: props.row }, this)">
                   <button
                     :key="index"
@@ -338,8 +338,8 @@
 
               <span v-else-if="props.column.field === '__ACTIONS'" class="text-right aw-table-actions-field">
                 <slot name="table-row-actions" :item="props.row">
-                  <template v-if="optionsComputed && optionsComputed.customInlineActions">
-                    <template v-for="(action, index) in optionsComputed.customInlineActions">
+                  <template v-if="customInlineActions">
+                    <template v-for="(action, index) in customInlineActions">
                       <template v-if="!action.canDisplay || action.canDisplay({ item: props.row }, this)">
                         <button
                           :key="index"
@@ -532,8 +532,6 @@ export default {
         fixedHeader: false,
         maxHeight: '',
         pagination: true,
-        customInlineActions: [], // {key, label, action: function(item, context{}}
-        customBulkActions: [],
         filterInitiallyOn: false
       })
     },
@@ -542,7 +540,21 @@ export default {
       default: () => defaultActions,
       note: 'actions active in this instance'
     },
-
+    customInlineActions: {
+      type: Array,
+      default: () => [],
+      note: 'custom inline action in row'
+    },
+    customTableTopActions: {
+      type: Array,
+      default: () => [],
+      note: 'custom table top actions'
+    },
+    customBulkActions: {
+      type: Array,
+      default: () => [],
+      note: 'custom bulk action'
+    },
     mode: {
       default: '',
       type: String,


### PR DESCRIPTION
I used a computed to also keep the old way to avoid regressions

> Trello card : https://trello.com/c/9yUYBWX7/77-awesomecrud-move-all-custom-actions-that-are-in-the-options-object-into-first-level-props